### PR TITLE
fixes print sentence task

### DIFF
--- a/src/main/java/lang/print/gaps/task1/PrintSentenceApp.java
+++ b/src/main/java/lang/print/gaps/task1/PrintSentenceApp.java
@@ -1,6 +1,4 @@
 package lang.print.gaps.task1;
 
 public class PrintSentenceApp {
-    public static void main(String[] args) {
-    }
 }


### PR DESCRIPTION
PrintSentenceApp class did not match the task description. It already had `psvm` in it.